### PR TITLE
Adding post fixes to hand cannons so that they can be identified based on the book they're from

### DIFF
--- a/packages/emporium/src/assets/data/weapons/CRB.json
+++ b/packages/emporium/src/assets/data/weapons/CRB.json
@@ -357,8 +357,8 @@
       "Steampunk"
     ]
   },
-  "handCannon": {
-    "name": "Hand Cannon",
+  "handCannonCore": {
+    "name": "Hand Cannon (Core)",
     "skill": "RangedLight",
     "damage": 9,
     "critical": 3,

--- a/packages/emporium/src/assets/data/weapons/SOTB.json
+++ b/packages/emporium/src/assets/data/weapons/SOTB.json
@@ -55,7 +55,7 @@
     "page": 82
   },
   "handCannon": {
-    "name": "Hand Cannon",
+    "name": "Hand Cannon (SOTB)",
     "skill": "RangedLight",
     "damage": 7,
     "critical": 3,


### PR DESCRIPTION
Added Core postfix to core's hand cannon ID because everyone will be referencing the SOTB version right now due to how merging works, so keeping that one's ID the same.