### PR TITLE
[Enhancement] Ranked talents should only show up in higher tiers if b…

### DIFF
--- a/packages/emporium/src/app/components/TalentSelection.tsx
+++ b/packages/emporium/src/app/components/TalentSelection.tsx
@@ -54,9 +54,7 @@ class TalentSelectionComponent extends React.Component<any, any> {
                 }
                 //talent is ranked and has been selected enough for this tier
                 if (
-                    talents[key].ranked && talentCount[key]
-                        ? +tier !== +talents[key].tier + talentCount[key]
-                        : false
+                    talents[key].ranked && +tier !== +talents[key].tier + (+talentCount[key] || 0)
                 ) {
                     return false;
                 }

--- a/packages/emporium/src/assets/data/talents/ROT.json
+++ b/packages/emporium/src/assets/data/talents/ROT.json
@@ -20,7 +20,7 @@
     "tier": 1,
     "activation": true,
     "turn": "Incidental",
-    "ranked": true,
+    "ranked": false,
     "book": "ROT",
     "page": "84",
     "description": "See ROT, page 84, for more details."

--- a/packages/emporium/src/assets/data/talents/SOTB.json
+++ b/packages/emporium/src/assets/data/talents/SOTB.json
@@ -617,7 +617,7 @@
     "activation": true,
     "turn": "Incidental",
     "ranked": false,
-    "prerequiste": "UndercityContacts",
+    "prerequisite": "UndercityContacts",
     "book": "SOTB",
     "page": 51,
     "description": "See SOTB, page 51, for more details."


### PR DESCRIPTION
…ought at lower tiers #63

- refactored logic to determine when to display ranked talents
- marked Bullrush as not ranked
- UndercityContactsImproved now correctly requires UndercityContacts