### PR TITLE
Inorganic is duplicated under talents for bioroids #22

### DIFF
--- a/packages/emporium/src/assets/data/archetypes/SOTB.json
+++ b/packages/emporium/src/assets/data/archetypes/SOTB.json
@@ -24,8 +24,8 @@
     "Willpower": 2,
     "Presence": 2
   },
-  "Bioroid": {
-    "name": "Bioroid",
+  "BioroidSOTB": {
+    "name": "Bioroid (SotB)",
     "book": "SOTB",
     "page": 26,
     "description": "See SOTB, page 26, for more details.",


### PR DESCRIPTION
- made a distinction between CRB and SotB bioroids
(same as with Clone)